### PR TITLE
Fix DateValidatorType

### DIFF
--- a/Example/RxValidatorExample/RxValidatorExampleTests/DateValidateTests.swift
+++ b/Example/RxValidatorExample/RxValidatorExampleTests/DateValidateTests.swift
@@ -20,7 +20,7 @@ class DateValidateTests: XCTestCase {
     func testDateValidation() {
         
         let targetDate = "2018-05-29T12:00+09:00".date(format: .iso8601Auto)!.absoluteDate
-        let afterTargetDate = "2018-05-29T12:00+09:00".date(format: .iso8601Auto)!.absoluteDate
+        let afterTargetDate = "2018-05-29T12:01+09:00".date(format: .iso8601Auto)!.absoluteDate
         let beforeTargetDate = "2018-05-29T11:59+09:00".date(format: .iso8601Auto)!.absoluteDate
         let sameTargetDate = "2018-05-29T12:00+09:00".date(format: .iso8601Auto)!.absoluteDate
         

--- a/Example/RxValidatorExample/RxValidatorExampleTests/DateValidateTests.swift
+++ b/Example/RxValidatorExample/RxValidatorExampleTests/DateValidateTests.swift
@@ -49,6 +49,53 @@ class DateValidateTests: XCTestCase {
         expect(resultDate).toEventually(equal(targetDate))
     }
     
+    func testDateValidationShouldBeforeThenWithSameTargetDate() {
+        // given
+        let targetDate = "2018-05-29T12:00+09:00".date(format: .iso8601Auto)!.absoluteDate
+        let sameTargetDate = "2018-05-29T12:00+09:00".date(format: .iso8601Auto)!.absoluteDate
+        var resultDate: Date?
+        var resultError: RxValidatorResult = .valid
+        let underTest = DateValidationTarget(targetDate)
+        
+        // when
+        underTest
+            .validate(.shouldBeforeThen(date: sameTargetDate))
+            .asObservable()
+            .subscribe(onNext: { (date) in
+                resultDate = date
+            }, onError: { (error) in
+                resultError = RxValidatorResult.determine(error: error)
+            }).disposed(by: disposeBag)
+        
+        // then
+        // it should not before date
+        expect(resultError).toEventually(equal(RxValidatorResult.notBeforeDate))
+        expect(resultDate).toEventually(beNil())
+    }
+    
+    func testDateValidationShouldAfterThenWithSameTargetDate() {
+        // given
+        let targetDate = "2018-05-29T12:00+09:00".date(format: .iso8601Auto)!.absoluteDate
+        let sameTargetDate = "2018-05-29T12:00+09:00".date(format: .iso8601Auto)!.absoluteDate
+        var resultDate: Date?
+        var resultError: RxValidatorResult = .valid
+        let underTest = DateValidationTarget(targetDate)
+        
+        // when
+        underTest
+            .validate(.shouldAfterThen(date: sameTargetDate))
+            .asObservable()
+            .subscribe(onNext: { (date) in
+                resultDate = date
+            }, onError: { (error) in
+                resultError = RxValidatorResult.determine(error: error)
+            }).disposed(by: disposeBag)
+        
+        // then
+        // it should not after date
+        expect(resultError).toEventually(equal(RxValidatorResult.notAfterDate))
+        expect(resultDate).toEventually(beNil())
+    }
     
     func testDateValidationWithAllday() {
         let targetDate = "2018-05-29T12:00:00+09:00".date(format: .iso8601Auto)!.absoluteDate

--- a/Sources/rules/Date/DateValidatorType.swift
+++ b/Sources/rules/Date/DateValidatorType.swift
@@ -35,7 +35,7 @@ public enum DateValidatorType {
             }
         case let .shouldBeforeOrSameThen(comparison):
             let result = calendar.compare(value, to: comparison, toGranularity: granularity)
-            if result == .orderedAscending {
+            if result == .orderedDescending {
                 throw RxValidatorResult.notBeforeDate
             }
         case let .shouldAfterThen(comparison):

--- a/Sources/rules/Date/DateValidatorType.swift
+++ b/Sources/rules/Date/DateValidatorType.swift
@@ -30,7 +30,7 @@ public enum DateValidatorType {
             }
         case let .shouldBeforeThen(comparison):
             let result = calendar.compare(value, to: comparison, toGranularity: granularity)
-            if result == .orderedDescending {
+            if result != .orderedAscending {
                 throw RxValidatorResult.notBeforeDate
             }
         case let .shouldBeforeOrSameThen(comparison):
@@ -40,12 +40,12 @@ public enum DateValidatorType {
             }
         case let .shouldAfterThen(comparison):
             let result = calendar.compare(value, to: comparison, toGranularity: granularity)
-            if result == .orderedAscending {
+            if result != .orderedDescending {
                 throw RxValidatorResult.notAfterDate
             }
         case let .shouldAfterOrSameThen(comparison):
             let result = calendar.compare(value, to: comparison, toGranularity: granularity)
-            if !(result != .orderedAscending) {
+            if result == .orderedAscending {
                 throw RxValidatorResult.notAfterDate
             }
         case let .shouldBeCloseDates(comparison, termOfDays):            


### PR DESCRIPTION
Given `func testDateValidation()` does not cover after target date because it's same to target date

```swift
let targetDate = "2018-05-29T12:00+09:00".date(format: .iso8601Auto)!.absoluteDate
let afterTargetDate = "2018-05-29T12:00+09:00".date(format: .iso8601Auto)!.absoluteDate
```

- Add unit test for after target date and fix failed test case
- Add unit test for same target date when validate with `.shouldBeforeThen` or `.shouldAfterThen`  fix failed test case

related links
https://developer.apple.com/documentation/foundation/comparisonresult
> Constants
case orderedAscending
The left operand is smaller than the right operand.

> case orderedSame
The two operands are equal.

> case orderedDescending
The left operand is greater than the right operand.